### PR TITLE
Feat: Add mounted drive support and improve keep-awake reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Workspace folder
+_workspace/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/NoSleepHD.Core/Global/MainGlobal.cs
+++ b/NoSleepHD.Core/Global/MainGlobal.cs
@@ -14,7 +14,9 @@ namespace NoSleepHD.Core.Global
 
         public static readonly string AppStartupPath = $"\"{AppCorePath}\" Nothing";
 
-        public static string[] Disks
+		public const string MarkerFileName = "NoSleepHD";
+
+		public static string[] Disks
         {
             get
             {

--- a/NoSleepHD/Assets/Lang/en-US.xaml
+++ b/NoSleepHD/Assets/Lang/en-US.xaml
@@ -10,6 +10,8 @@
     <s:String x:Key="text_nosleep_start">Start</s:String>
     <s:String x:Key="text_nosleep_stop">Stop</s:String>
 
+    <s:String x:Key="text_mounted_drives">Mounted Drives</s:String>
+
     <s:String x:Key="you_have_not_selected_any_hdd">Please select HDD Driver</s:String>
 
     <s:String x:Key="text_warning">Warning</s:String>

--- a/NoSleepHD/Assets/Lang/zh-CN.xaml
+++ b/NoSleepHD/Assets/Lang/zh-CN.xaml
@@ -10,6 +10,8 @@
     <s:String x:Key="text_nosleep_start">启动</s:String>
     <s:String x:Key="text_nosleep_stop">停止</s:String>
 
+    <s:String x:Key="text_mounted_drives">已挂载的驱动器</s:String>
+
     <s:String x:Key="you_have_not_selected_any_hdd">请至少选择一个硬盘</s:String>
 
     <s:String x:Key="text_warning">警告</s:String>

--- a/NoSleepHD/NoSleepHD.csproj
+++ b/NoSleepHD/NoSleepHD.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>hdd.ico</ApplicationIcon>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Authors>hyydsz</Authors>
     <Company>hyydsz</Company>
     <Product />

--- a/NoSleepHD/View/MainView.xaml
+++ b/NoSleepHD/View/MainView.xaml
@@ -7,7 +7,10 @@
              mc:Ignorable="d"
              d:DesignHeight="400"
              d:DesignWidth="400">
-
+    <UserControl.Resources>
+        <!-- This converter is used to hide the mounted drives section when it's empty -->
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </UserControl.Resources>
     <DockPanel>
 
         <Grid DockPanel.Dock="Bottom">
@@ -54,30 +57,59 @@
             <ScrollViewer Margin="10"
                           VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Disabled">
+                <!-- We use a StackPanel to arrange the two sections vertically -->
+                <StackPanel>
 
-                <ItemsControl ItemsSource="{Binding DiskLists}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <ToggleButton Command="{Binding DataContext.DiskButtonCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                          CommandParameter="{Binding}"
-                                          IsChecked="{Binding IsChecked}"
-                                          Content="{Binding Path}"
-                                          Margin="5"/>
+                    <!-- Section 1: Normal Disks -->
+                    <ItemsControl ItemsSource="{Binding NormalDisks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <ToggleButton Command="{Binding DataContext.DiskButtonCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                              CommandParameter="{Binding}"
+                                              IsChecked="{Binding IsChecked}"
+                                              Content="{Binding Path}"
+                                              Margin="5"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
 
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
+                    <!-- Section 2: Mounted Disks (only visible if any exist) -->
+                    <StackPanel Visibility="{Binding HasMountedDisks, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Separator Margin="5,10" />
 
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                </ItemsControl>
+                        <TextBlock
+                            Text="{DynamicResource text_mounted_drives}"
+                            FontWeight="SemiBold"
+                            Margin="5,0,0,5"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
 
+                        <ItemsControl ItemsSource="{Binding MountedDisks}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <ToggleButton Command="{Binding DataContext.DiskButtonCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                  CommandParameter="{Binding}"
+                                                  IsChecked="{Binding IsChecked}"
+                                                  Content="{Binding Path}"
+                                                  Margin="5"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </StackPanel>
+
+                </StackPanel>
             </ScrollViewer>
 
             <Separator VerticalAlignment="Bottom" />
-
         </Grid>
 
     </DockPanel>

--- a/NoSleepHD/ViewModel/WindowViewModel.cs
+++ b/NoSleepHD/ViewModel/WindowViewModel.cs
@@ -42,7 +42,7 @@ namespace NoSleepHD.ViewModel
 		[DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
 		private static extern bool GetVolumePathNamesForVolumeName(
 			string lpszVolumeName,
-			[Out] char[] lpszVolumePathNames,
+			[Out] char[]? lpszVolumePathNames,
 			uint cchBufferLength,
 			out uint lpcchReturnLength);
 


### PR DESCRIPTION
### 功能: 新增挂载驱动器支持；并提高唤醒可靠性

此 PR 包含两项主要变更：
### 1. 支持挂载式驱动器
为增加对**挂载为 NTFS 文件夹的驱动器**的支持，通过使用 WinAPI 的卷枚举替代 DriveInfo.GetDrives() 来解决，确保所有固定磁盘无论其挂载点如何都能被发现。

### 2. 更可靠的硬盘唤醒机制
在测试中，发现当前版本的只读方法 (GetFileSystemEntries) 无法正确地阻止硬盘休眠，猜测可能是由于操作系统的文件缓存机制所致。因此重新引入了基于文件的策略，以确保磁盘操作的执行：
- 在**启动**时创建标记文件，**停止**时移除。
- 唤醒操作是对该文件进行一次极微小的元数据写入 (SetLastAccessTimeUtc)。该操作可以绕过系统缓存，从而可靠地重置硬盘的空闲计时器，且最小化了对硬盘的写入。

---

### Feat: Add mounted drive support and improve keep-awake reliability

This PR introduces two key improvements:
### 1. Support for Mounted Drives
The current implementation fails to detect drives mounted as NTFS folders. This has been resolved by replacing DriveInfo.GetDrives() with a WinAPI-based volume enumeration, ensuring all fixed drives are discovered regardless of their mount point.

### 2. More Reliable Keep-Awake Mechanism
In testing, the current read-only method (GetFileSystemEntries) failed to reliably prevent HDDs from sleeping. We suspect this is due to the OS file system cache serving subsequent requests from RAM. This PR re-introduces a file-based strategy to guarantee a physical disk operation:
- A marker file is created on **start** and removed on **stop**.
- The keep-awake action is a minimal metadata write (SetLastAccessTimeUtc) to this file. This bypasses the OS cache to reliably reset the disk's idle timer while minimizing writes to the disk.